### PR TITLE
mod: Automata url

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ An experimental open-source attempt to make GPT-4 fully autonomous, with >140k s
 
 
 
-## [Automata](https://github.com/emrgnt-cmplxty)
+## [Automata](https://github.com/emrgnt-cmplxty/automata)
 Crafting a sophisticated system that autonomously generates its own code based on the context of your project.
 
 <details>


### PR DESCRIPTION
Currently the Automata link points to the *[maintainer of Automata](https://github.com/emrgnt-cmplxty)*, rather than the [Github Repository](https://github.com/emrgnt-cmplxty/automata).