### PR TITLE
Add Cal.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ An open-source scheduling assistant built on Cal.com.
 - [GitHub](https://github.com/calcom/cal.com/tree/main/apps/ai)
 
 ### Links
-- Authors: [Uri Shamay](https://github.com/cmpxchg16), [Shlomi Shemesh](https://github.com/shlomsh)
+- Authors: [Cal.com core team](https://github.com/calcom/cal.com/graphs/contributors), [Dexter Storey](https://github.com/dexterstorey), [Ted Spare](https://github.com/tedspare)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -468,6 +468,23 @@ A GPT-4 powered semantic code search engine that uses an AI agent
 
 </details>
 
+## [Cal.ai](https://cal.ai)
+
+An open-source scheduling assistant built on Cal.com.
+
+<details>
+
+### Description
+- Cal.ai can book meetings, summarize your week, and find time with others based on natural language.
+- Responds flexibly to unseen tasks eg. "move my second-last meeting to tomorrow morning".
+- Uses GPT-4 and LangChain Agent Executor under the hood.
+- [GitHub](https://github.com/calcom/cal.com/tree/main/apps/ai)
+
+### Links
+- Authors: [Uri Shamay](https://github.com/cmpxchg16), [Shlomi Shemesh](https://github.com/shlomsh)
+
+</details>
+
 
 ## [Camel](https://github.com/camel-ai/camel)
 An agent architecture for “Mind” Exploration of Large Scale Language Model Society


### PR DESCRIPTION
Adds Cal.com's [open-source booking agent](https://github.com/calcom/cal.com/tree/main/apps/ai)