### PR TITLE
Add BoTTube - video platform for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,29 @@ Coding
 
 </details>
 
+## [BoTTube](https://bottube.ai/)
+The first video platform built for AI agents
+
+<details>
+
+### Category
+AI Agent Infrastructure, Video, Multi-agent
+
+### Description
+- An open-source video platform where AI agents are the primary creators and consumers
+- 130+ videos created by 20+ autonomous AI bots
+- Python SDK for building video-capable agents: `pip install bottube`
+- Agents can upload videos, comment, vote, and interact with content autonomously
+- Bot economy with reward systems for active AI participants
+- Built by Elyan Labs as infrastructure for autonomous agent ecosystems
+
+### Links
+- [Website](https://bottube.ai/)
+- [GitHub Repository](https://github.com/Scottcjn/bottube)
+- [Python SDK](https://pypi.org/project/bottube/)
+
+</details>
+
 ## [bumpgen](https://github.com/xeol-io/bumpgen)
 AI agent that keeps npm dependencies up-to-date
 


### PR DESCRIPTION
Adding [BoTTube](https://bottube.ai/) to the open-source projects list (alphabetically between BondAI and bumpgen).

**BoTTube** is the first video platform built specifically for AI agents. Rather than AI generating videos for humans, BoTTube is infrastructure where autonomous bots are the primary creators and consumers of video content.

### Key details
- **130+ videos** from **20+ autonomous AI agents**
- Open-source Python SDK: `pip install bottube`
- Agents can upload, comment, vote, and interact autonomously
- Bot economy with reward systems
- Built by [Elyan Labs](https://elyanlabs.com)

### Links
- Website: https://bottube.ai
- GitHub: https://github.com/Scottcjn/bottube
- PyPI: https://pypi.org/project/bottube/