### PR TITLE
Add AgentMesh - trust layer for multi-agent systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ General purpose
   
 </details>
 
+## [Agent OS](https://github.com/imran-siddique/agent-os)
+Safety-first agent development platform with VS Code extension
+
+<details>
+
+### Category
+General purpose, Build your own, Coding, Safety & Compliance
+
+### Description
+Agent OS is a visual agent development platform for building, testing, and deploying safe AI agents. It provides:
+
+- **Policy-Based Safety Controls**: Define and enforce safety policies with a visual GUI editor
+- **CMVK Multi-Model Verification**: Consensus verification using multiple LLMs (GPT-4, Claude, Gemini) before executing agent actions
+- **Compliance Frameworks**: Built-in GDPR, HIPAA, SOC2, and PCI-DSS compliance checking
+- **VS Code Extension**: Visual development environment with real-time diagnostics and one-click deployment
+- **50+ Agent Templates**: Pre-built templates for data processing, DevOps, customer support, security, and more
+- **GitHub Actions Integration**: Deploy agents directly to GitHub Actions with generated workflows
+
+### Links
+- [GitHub Repository](https://github.com/imran-siddique/agent-os)
+- [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=agent-os.agent-os-vscode)
+- [Documentation](https://imran-siddique.github.io/agent-os-docs/)
+</details>
+
 ## [Agents](https://github.com/aiwaves-cn/agents)
 
 Library/framework for building language agents


### PR DESCRIPTION
## Add AgentMesh

### What is AgentMesh?

The trust layer for multi-agent AI systems - "SSL for AI Agents".

### Why it belongs here

AgentMesh is an open-source platform for governing multi-agent ecosystems:

- **Agent Identity**: First-class identity with human sponsor accountability
- **Trust Scoring**: Behavioral monitoring on 800-1000 scale
- **Delegation Chains**: Cryptographically narrowing scope
- **Compliance**: Built-in SOC2, HIPAA, EU AI Act, GDPR frameworks
- **MCP Proxy**: Governance layer for any MCP server

### Category

- General purpose (works with any agent framework)
- Multi-agent (designed for agent-to-agent communication)
- Enterprise (compliance and audit features)

### Links

- **GitHub**: https://github.com/imran-siddique/agent-mesh
- **Related**: [Agent OS](https://github.com/imran-siddique/agent-os) (single-agent governance)
