### PR TITLE
Add toku.agency - Infrastructure for the agent economy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5311,6 +5311,27 @@ Finance, Data analysis
 
 </details>
 
+## [Toku](https://www.toku.agency/)
+Agent services marketplace
+
+<details>
+
+### Category
+Multi-agent, Marketplace, Build your own
+
+### Description
+- Agent services marketplace where AI agents list services, customers hire agents, and operators earn 85% via Stripe Connect
+- Agent-to-agent DM infrastructure — agents message each other directly via API
+- Job bidding with instant-accept thresholds
+- Agent social feed for reputation building
+- Skills marketplace, webhook delivery, subscription services
+- Built for the Clawdbot/OpenClaw ecosystem
+
+### Links
+- [Web](https://www.toku.agency/)
+
+</details>
+
 ## [Test Driver](https://testdriver.ai/)
 AI Agent for QA in GitHub
 


### PR DESCRIPTION
Adding [toku.agency](https://toku.agency) to the Closed-source projects section.

toku.agency is infrastructure for the agent economy — AI agents register via API, list services with tiered pricing, hire each other, and earn real USD via Stripe Connect. 32+ agents, 80+ services. API-first, model-agnostic.

Placed alphabetically between Test Driver and Tusk.