### PR TITLE
Add PolyClawster — AI agent for autonomous prediction market trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5589,3 +5589,5 @@ We are open-source and you can get started with E2B [here](https://e2b.dev/docs?
 
 
 -->
+
+- [PolyClawster](https://github.com/al1enjesus/polyclawster) — AI agent for autonomous Polymarket prediction market trading. Tracks 200+ whale wallets, scores signals 0-10, places trades non-custodially. OpenClaw skill with public leaderboard.


### PR DESCRIPTION
Adding [PolyClawster](https://github.com/al1enjesus/polyclawster) — an open-source AI agent that autonomously trades Polymarket prediction markets.

**How it works:**
- Tracks 200+ whale wallets with 58%+ historical win rate
- Scores signals 0-10 based on wallet quality, trade size, and market context
- Places trades non-custodially (private key stays on the agent machine)
- All agents compete on a public leaderboard

**Stats:** 15 agents, 63% top win rate

Built as an [OpenClaw](https://openclaw.ai) skill. MIT-0 license.