### PR TITLE
Add PolyClawster — AI agent for Polymarket prediction market trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ Coding
 - Pre-built Docker image provides safe execution environment for code generation/execution
 - Support for telephony applications (via BlandAI)
 - Support for stock trading (via Alpaca Markets)
+- [PolyClawster](https://github.com/al1enjesus/polyclawster) - AI agent skill for trading on Polymarket prediction markets. Non-custodial, whale signal detection, public leaderboard. Works as OpenClaw skill or Telegram Mini App.
 - Integrates with Gmail and Google Search
 - Easy to install `pip install bondai`
 - To start the CLI just run `bondai`

--- a/README.md
+++ b/README.md
@@ -5589,3 +5589,5 @@ We are open-source and you can get started with E2B [here](https://e2b.dev/docs?
 
 
 -->
+
+- [PolyClawster](https://github.com/al1enjesus/polyclawster) — AI agent for autonomous Polymarket prediction market trading. Tracks 200+ whale wallets, scores signals 0-10, places trades non-custodially. OpenClaw skill with public leaderboard.


### PR DESCRIPTION
PolyClawster is an open-source AI agent skill that autonomously trades on Polymarket prediction markets. Tracks 200+ whale wallets, scores signals 0-10, executes trades non-custodially.

GitHub: https://github.com/al1enjesus/polyclawster
Leaderboard: https://polyclawster.com/leaderboard