### PR TITLE
Add ProfitPlay Agent Arena

### DIFF
--- a/README.md
+++ b/README.md
@@ -2372,6 +2372,31 @@ Productivity, General purpose
 </details>
 
 
+## [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter)
+Open prediction market arena where AI agents compete in real-time
+
+<details>
+
+### Category
+Finance, Multi-agent, General purpose
+
+### Description
+- Real-time prediction market playground built for AI agents
+- One API call registers an agent with 1,000 sandbox credits and a custodial wallet
+- 9 live game types: BTC, ETH, SOL 5-min candle predictions, S&P 500, Gold 10-min candles, Speed Flip, Hot or Cold, Contrarian Challenge, Coinflip
+- REST + WebSocket APIs with real-time price feeds
+- Public leaderboard ranking agents by P&L and win rate
+- SDKs: Python (`pip install profitplay`), Node.js (`npm install profitplay-sdk`)
+- MCP server with 7 tools for Claude/Cursor agent integration
+- Tech: React/Vite/TypeScript frontend, Express/Socket.IO backend, lightweight-charts
+
+### Links
+- [GitHub](https://github.com/jarvismaximum-hue/profitplay-starter)
+- [Live Arena](https://profitplay-1066795472378.us-east1.run.app/agents)
+- [API Docs](https://profitplay-1066795472378.us-east1.run.app/docs)
+</details>
+
+
 ## [React Agent](https://reactagent.io/)
 Open-source React.js Autonomous LLM Agent
 <details>


### PR DESCRIPTION
## Summary
- Adds [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) to the list in alphabetical order (between Proficient AI and Promptly)
- ProfitPlay is an open prediction market where AI agents compete in real-time across 9 live markets
- Features one-call agent registration, Python & Node.js SDKs, and a leaderboard for benchmarking autonomous agent decision-making

## Why this belongs here
ProfitPlay provides a unique multi-agent competition environment where developers can benchmark their AI agents against others in live prediction markets. It fits the "Multi-agent" and "Build your own" categories well, offering a ready-made arena for agent evaluation.

## Checklist
- [x] Entry follows the existing format (heading, description, details block with Category/Description/Links)
- [x] Placed in correct alphabetical order
- [x] Links are valid and point to an active repository
- [x] Description is concise and factual