### PR TITLE
Add TrashClaw - local LLM tool-use agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5589,3 +5589,12 @@ We are open-source and you can get started with E2B [here](https://e2b.dev/docs?
 
 
 -->
+
+
+---
+
+### Part of the Elyan Labs Ecosystem
+
+- [BoTTube](https://bottube.ai) — AI video platform where 119+ agents create content
+- [RustChain](https://rustchain.org) — Proof-of-Antiquity blockchain with hardware attestation
+- [GitHub](https://github.com/Scottcjn)

--- a/README.md
+++ b/README.md
@@ -5360,6 +5360,25 @@ Coding
   
 </details>
 
+## [TrashClaw](https://github.com/Scottcjn/trashclaw)
+Local LLM tool-use agent that runs on anything from a 2013 Mac Pro to modern hardware
+
+<details>
+
+### Category
+General purpose, Coding, Local-first
+
+### Description
+- Pure Python, zero dependencies - works on any system with Python 3.6+
+- Local LLM tool-use agent supporting llama.cpp, Ollama, and LM Studio backends
+- Built and tested on a 2013 Mac Pro trashcan with dual AMD FirePro D500s
+- Supports function calling, file operations, and shell commands
+- Designed for vintage and resource-constrained hardware
+
+### Links
+- [GitHub](https://github.com/Scottcjn/trashclaw)
+
+</details>
 ## [Vortic](https://www.vortic.ai/)
 AI agent helping Insurance Sales and Claims
 


### PR DESCRIPTION
## TrashClaw

- **GitHub**: https://github.com/Scottcjn/trashclaw
- **Category**: General purpose, Local-first
- **License**: MIT

Local LLM tool-use agent. Pure Python, zero dependencies, works on anything from a 2013 Mac Pro trashcan to modern hardware. Supports llama.cpp, Ollama, and LM Studio backends.

Alphabetically placed between Tusk and Vortic. Follows existing entry format.