### PR TITLE
Add Arch Tools — 58 production tools for AI agents with x402 + patent-pending auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5589,3 +5589,7 @@ We are open-source and you can get started with E2B [here](https://e2b.dev/docs?
 
 
 -->
+
+
+## Agent Tools
+- [Arch Tools](https://archtools.dev) - 58 production API tools for AI agents with x402 USDC payments, patent-pending agent auth, and MCP support. Web scraping, AI generation, crypto data, OCR, browser automation. ([GitHub](https://github.com/Deesmo/Arch-AI-Tools))


### PR DESCRIPTION
Adding Arch Tools — 58 production API tools for AI agents.

- x402 USDC payments on 15+ chains
- Patent-pending agent auth protocol
- MCP compatible
- 100 free credits

https://archtools.dev