### PR TITLE
Add SelfHeal — self-healing API proxy for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2427,6 +2427,22 @@ Productivity, Research
 
 </details>
 
+## [SelfHeal](https://selfheal.dev)
+Self-healing API proxy for AI agents
+
+<details>
+
+### Category
+Developer tools, Infrastructure
+
+### Description
+- Self-healing API proxy for AI agents. Intercepts failed API calls and returns LLM-powered fix instructions. SDKs for Python and Node.js.
+
+### Links
+- [Web](https://selfheal.dev)
+
+</details>
+
 ## [Smol developer](https://github.com/smol-ai/developer)
 Your own junior AI developer, deployed via E2B UI
 


### PR DESCRIPTION
Adding [SelfHeal](https://selfheal.dev) to the list of open source AI agent projects.

**SelfHeal** is a self-healing API proxy for AI agents. It intercepts failed API calls and returns LLM-powered fix instructions. SDKs available for Python (`pip install graceful-fail`) and Node.js (`npm install graceful-fail`).

Entry added in alphabetical order under Open source projects.