### PR TITLE
Add SkillClaw — collective skill evolution for OpenClaw-style agent ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -2964,9 +2964,7 @@ General purpose
 ## [SkillClaw](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
 Collective skill evolution for OpenClaw-style multi-user agent ecosystems
 
-<details>
-
-![image](https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png)
+<details> 
 
 ### Category
 General purpose, Build-your-own

--- a/README.md
+++ b/README.md
@@ -2961,6 +2961,31 @@ General purpose
 - Author: [PJ Gray](https://twitter.com/pj4533/?utm_source=awesome-ai-agents)
 </details>
 
+## [SkillClaw](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
+Collective skill evolution for OpenClaw-style multi-user agent ecosystems
+
+<details>
+
+![image](https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png)
+
+### Category
+General purpose, Build-your-own
+
+### Description
+SkillClaw is a Python framework that lets groups of OpenClaw-style agents **evolve and share reusable skills** from real session data with minimal change to how users already interact with their assistant.
+- **Client proxy** — Intercepts OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/messages`), records session artifacts, and syncs skills with shared storage.
+- **Evolve servers** — Fixed three-stage LLM workflow (Summarize → Aggregate → Execute) or an **agent-driven** path using OpenClaw to analyze sessions and write evolved skill files with tool access.
+- **Shared storage** — Alibaba OSS, S3, or local filesystem; common **SKILL.md** format so components stay interchangeable.
+- **Ecosystem** — Documented integration with PicoClaw, IronClaw, ZeroClaw, NanoClaw, NemoClaw, and related Claw-family stacks.
+- Includes experiment tooling around **WildClawBench** for evaluating iterative skill evolution.
+
+### Links
+- [GitHub Repository](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
+- [Paper (arXiv)](https://arxiv.org/abs/2604.08377/?utm_source=awesome-ai-agents)
+- [License: MIT](https://github.com/AMAP-ML/SkillClaw/blob/main/LICENSE/?utm_source=awesome-ai-agents)
+
+</details>
+
 # Closed-source projects and companies
 
 ## [Ability AI](https://ability.ai/)

--- a/README.md
+++ b/README.md
@@ -2427,6 +2427,32 @@ Productivity, Research
 
 </details>
 
+
+## [SkillClaw](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
+Collective skill evolution for OpenClaw-style multi-user agent ecosystems
+
+<details>
+
+![image](https://raw.githubusercontent.com/AMAP-ML/SkillClaw/main/assets/skillclaw_logo.png)
+
+### Category
+General purpose, Build-your-own
+
+### Description
+SkillClaw is a Python framework that lets groups of OpenClaw-style agents **evolve and share reusable skills** from real session data with minimal change to how users already interact with their assistant.
+- **Client proxy** — Intercepts OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/messages`), records session artifacts, and syncs skills with shared storage.
+- **Evolve servers** — Fixed three-stage LLM workflow (Summarize → Aggregate → Execute) or an **agent-driven** path using OpenClaw to analyze sessions and write evolved skill files with tool access.
+- **Shared storage** — Alibaba OSS, S3, or local filesystem; common **SKILL.md** format so components stay interchangeable.
+- **Ecosystem** — Documented integration with PicoClaw, IronClaw, ZeroClaw, NanoClaw, NemoClaw, and related Claw-family stacks.
+- Includes experiment tooling around **WildClawBench** for evaluating iterative skill evolution.
+
+### Links
+- [GitHub Repository](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
+- [Paper (arXiv)](https://arxiv.org/abs/2604.08377/?utm_source=awesome-ai-agents)
+- [License: MIT](https://github.com/AMAP-ML/SkillClaw/blob/main/LICENSE/?utm_source=awesome-ai-agents)
+
+</details>
+
 ## [Smol developer](https://github.com/smol-ai/developer)
 Your own junior AI developer, deployed via E2B UI
 
@@ -2961,30 +2987,7 @@ General purpose
 - Author: [PJ Gray](https://twitter.com/pj4533/?utm_source=awesome-ai-agents)
 </details>
 
-## [SkillClaw](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
-Collective skill evolution for OpenClaw-style multi-user agent ecosystems
 
-<details>
-
-![image](https://raw.githubusercontent.com/AMAP-ML/SkillClaw/main/assets/skillclaw_logo.png)
-
-### Category
-General purpose, Build-your-own
-
-### Description
-SkillClaw is a Python framework that lets groups of OpenClaw-style agents **evolve and share reusable skills** from real session data with minimal change to how users already interact with their assistant.
-- **Client proxy** — Intercepts OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/messages`), records session artifacts, and syncs skills with shared storage.
-- **Evolve servers** — Fixed three-stage LLM workflow (Summarize → Aggregate → Execute) or an **agent-driven** path using OpenClaw to analyze sessions and write evolved skill files with tool access.
-- **Shared storage** — Alibaba OSS, S3, or local filesystem; common **SKILL.md** format so components stay interchangeable.
-- **Ecosystem** — Documented integration with PicoClaw, IronClaw, ZeroClaw, NanoClaw, NemoClaw, and related Claw-family stacks.
-- Includes experiment tooling around **WildClawBench** for evaluating iterative skill evolution.
-
-### Links
-- [GitHub Repository](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
-- [Paper (arXiv)](https://arxiv.org/abs/2604.08377/?utm_source=awesome-ai-agents)
-- [License: MIT](https://github.com/AMAP-ML/SkillClaw/blob/main/LICENSE/?utm_source=awesome-ai-agents)
-
-</details>
 
 # Closed-source projects and companies
 

--- a/README.md
+++ b/README.md
@@ -2964,7 +2964,9 @@ General purpose
 ## [SkillClaw](https://github.com/AMAP-ML/SkillClaw/?utm_source=awesome-ai-agents)
 Collective skill evolution for OpenClaw-style multi-user agent ecosystems
 
-<details> 
+<details>
+
+![image](https://raw.githubusercontent.com/AMAP-ML/SkillClaw/main/assets/skillclaw_logo.png)
 
 ### Category
 General purpose, Build-your-own


### PR DESCRIPTION
## What am I adding?

Adding [SkillClaw](https://github.com/AMAP-ML/SkillClaw) to the open-source projects section.

SkillClaw is a Python framework for **collective skill evolution** in multi-user OpenClaw-style setups: a session-recording **client API proxy**, **evolve servers** (fixed LLM workflow or OpenClaw-driven agent), and **shared storage** (Alibaba OSS, S3, or local filesystem) so groups of agents can reuse evolved **Skills** (`SKILL.md`) without changing how end users already talk to their assistant. Documented integrations include PicoClaw, IronClaw, ZeroClaw, NanoClaw, NemoClaw, and related stacks. Includes WildClawBench-oriented experiment tooling and an [arXiv paper](https://arxiv.org/abs/2604.08377).

## Why does it belong here?

- Extends the autonomous / multi-agent ecosystem with **skill distillation and cross-agent sharing** from real session data
- **Open source** (MIT), active GitHub project with CLI and server components
- **OpenClaw-adjacent**: designed around OpenClaw-style agents and Claw-family runtimes
- **Research-backed** paper plus benchmark-oriented evaluation workflow

## Checklist

- [x] Alphabetical order maintained (between **Self-operating computer** and **Smol developer**)
- [x] Entry follows the existing format (`<details>`, category, description, links; logo via `raw.githubusercontent.com`)
- [x] Description is factual and concise
- [x] Links are valid and accessible
 