### PR TITLE
Add Not Human Search — agent-first search engine for AI-accessible tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2196,6 +2196,28 @@ Science, Multimodal, Social, Multi-agent
 
 </details>
 
+## [Not Human Search](https://nothumansearch.ai)
+Agent-first search engine for AI-accessible tools and APIs
+
+<details>
+
+### Category
+Developer tools, Agent infrastructure, Search
+
+### Description
+- Not Human Search is a search engine built for AI agents — indexes 9,000+ sites by how accessible they are to agents, not humans.
+- Every site is scored on agent-accessibility criteria: MCP server presence, OpenAPI spec, structured API, llms.txt, robots.txt compliance, and more.
+- Powers agent tool discovery: "find an API for X" returns ranked results with MCP endpoints and OpenAPI specs agents can immediately wire in.
+- Ships its own MCP server at `/mcp` — agents can search the index directly via JSON-RPC without any browser interaction.
+- Open source.
+
+### Links
+- [Website](https://nothumansearch.ai)
+- [GitHub](https://github.com/unitedideas/nothumansearch)
+- [MCP server](https://nothumansearch.ai/mcp)
+
+</details>
+
 ## [OpenAgents](https://github.com/xlang-ai/OpenAgents)
 Multi-agent general purpose platform
 <details>


### PR DESCRIPTION
## What is this?

[Not Human Search](https://nothumansearch.ai) is a search engine built specifically for AI agents. It indexes 9,000+ sites and ranks them by how accessible they are to agents — not humans.

## Why it belongs here

This list covers AI agents and agent infrastructure. Not Human Search is agent infrastructure: it solves the discovery problem for agents that need to find tools, APIs, and MCP servers at runtime.

- Every indexed site is scored on agent-accessibility: MCP server, OpenAPI spec, structured API, llms.txt, robots.txt compliance
- Agents can search the index directly via its own MCP server at `nothumansearch.ai/mcp` (JSON-RPC, no browser required)
- Open source: [github.com/unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch)

## Placement

Added alphabetically in Open-source projects between NLSOM and OpenAgents, matching the existing `## [Name](url) / tagline / <details> / ### Category / ### Description / ### Links` format.