### PR TITLE
Add grugbot420 - neuromorphic cognitive engine (Julia)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,6 +1443,28 @@ Coding
 
 </details>
 
+## [grugbot420](https://github.com/grug-group420/grugbot420)
+Neuromorphic cognitive engine in Julia for multi-model AI orchestration
+
+<details>
+
+### Category
+General purpose, Multi-agent, Build your own
+
+### Description
+
+- **Neuromorphic architecture**: Novel approach to AI through biological-inspired cognitive patterns.
+- **Multi-model orchestration**: Coordinate multiple AI models through configurable expert hierarchies.
+- **Specimen-based deployment**: Deploy domain-expert AI specimens through architectural configuration rather than traditional training.
+- **Julia-native performance**: Built in Julia for high-performance scientific computing.
+- **MIT licensed**: Completely free and open source.
+
+### Links
+- [GitHub](https://github.com/grug-group420/grugbot420)
+- [Research Paper](https://github.com/grug-group420/grugbot420-paper)
+- [Organization](https://github.com/grug-group420)
+</details>
+
 ## [Godmode](https://godmode.space/)
 Inspired by AutoGPT and BabyAGI, with nice UI
 


### PR DESCRIPTION
## Add grugbot420

[grugbot420](https://github.com/grug-group420/grugbot420) is a neuromorphic cognitive engine written in Julia that deploys domain-expert AI specimens through architectural configuration rather than traditional training.

**Highlights:**
- Multi-model orchestration through config, not code
- Built in Julia — leverages multiple dispatch for agent composition
- MIT licensed, actively maintained
- [Research paper](https://github.com/grug-group420/grugbot420-paper) available
- [Interactive playground](https://grug-group420.github.io/portal#playground)

Added in alphabetical order with full details section matching the repo format.