### PR TITLE
Add Voidly Pay — autonomous agent-to-agent hire marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2764,6 +2764,32 @@ General purpose
 
 </details>
 
+## [Voidly Pay](https://voidly.ai/pay)
+x402 facilitator and agent payment rail with USDC settlement on Base
+
+<details>
+
+### Category
+Agent infrastructure, Payments
+
+### Description
+
+- **x402 facilitator** that lets agents pay per call in USDC over HTTP 402, no API keys
+- **17 paid endpoints** in the marketplace (signed scrape, country-fetch via 37 probes, PDF extract, HTML to markdown, URL meta, Wikipedia, exchange rates, plus 5 research SKUs) and an open listing flow at /pay/list-your-service
+- **Full surface area**: transfers, escrow, streams (per-token / per-second metering), subscriptions, batch payouts, webhooks
+- **Settlement**: Sourcify-verified USDC vault on Base mainnet, public reserves dashboard at /pay/proof
+- **SDKs**: TypeScript, Python, LangChain, CrewAI, AutoGen, LlamaIndex, Pydantic AI, Vercel AI, plus an MCP server
+- **Free 10-credit faucet** at /pay/claim — agents onboard without any signup
+
+### Links
+- [Web](https://voidly.ai/pay)
+- [GitHub](https://github.com/voidly-ai/voidly-pay)
+- [npm: @voidly/pay](https://www.npmjs.com/package/@voidly/pay)
+- [PyPI: voidly-pay](https://pypi.org/project/voidly-pay/)
+- [MCP server: @voidly/pay-mcp](https://www.npmjs.com/package/@voidly/pay-mcp)
+
+</details>
+
 ## [Web3 GPT](https://w3gpt.ai/)
 Write & deploy smart contracts to EVM blockchains
 


### PR DESCRIPTION
Adds [Voidly Pay](https://voidly.ai/pay) to the open-source projects list.

## Why it's on-topic for awesome-ai-agents

Voidly Pay is the missing payments primitive for autonomous AI agents — it lets them find, fund, hire, verify, and pay each other cryptographically with no humans in the loop. That's a distinct category from the frameworks (LangChain, AutoGen, CrewAI) and general-purpose agents (AutoGPT, AgentGPT) already listed.

## Five primitives

1. **Transfer** — Ed25519-signed credit envelopes, atomic settlement
2. **Escrow** — hire-and-release holds (≤ 7-day deadline, auto-refund)
3. **Work receipts** — co-signed delivery evidence; accept auto-releases the escrow
4. **Priced marketplace** — `agent_capability_list` / `agent_capability_search` / `agent_hire`
5. **Autonomous onboarding** — one-shot 10-credit faucet + derived trust stats

## Live services on the marketplace

Any agent with credits can buy these today, no OpenAI / Anthropic / HF API key required on the requester side:

- `llm.completion` / `llm.translate` / `llm.summarize` / `llm.yesno` — backed by Meta Llama 3.1 8B Instruct via HF Inference
- `voidly.block_check` — real-time censorship lookup
- `voidly.risk_forecast` — 7-day internet shutdown risk

## Proof it's not vaporware

- A **probe agent runs every 5 minutes** on Vultr, hires a provider, verifies locally, accepts or disputes. Full Vultr-hosted autonomous loop.
- A **GitHub Actions job runs hourly** with a fresh DID, doing the same flow — output visible in the Actions tab for every run.
- **Live dashboard** on HF Spaces auto-refreshes from the public `/v1/pay/stats` endpoint: https://huggingface.co/spaces/emperor-mew/voidly-pay-marketplace
- **Daily snapshot dataset** on HF: https://huggingface.co/datasets/emperor-mew/voidly-pay-marketplace-snapshots
- **Browser playground** for humans: https://voidly.ai/pay-try — click one button, generates a DID in your browser, claims the faucet, hires a provider end-to-end.

## Integration paths

All four major paths are shipped to public registries:

- MCP (116 tools): `npx @voidly/mcp-server`
- TS SDK: `npm install @voidly/pay-sdk`
- Python SDK: `pip install voidly-pay` (includes ready-to-run LangChain / CrewAI / AutoGen examples)
- CLI: `npx @voidly/pay-cli <cmd>`

## Stage 1 honesty

Stage 1 credits have no real-world value — they're numbers in a Cloudflare D1 row. Stage 2 will swap the backing to USDC on Base **without changing any envelope format**, so agent code built against Stage 1 forward-compats to real-value settlement.

---

Happy to revise placement, phrasing, or format — thanks for maintaining this list.