### PR TITLE
Add Omnigraph - typed graph DB for agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2208,7 +2208,7 @@ Build your own, General purpose
 - Typed graph database designed as persistent memory and source of truth for AI agents
 - Git-style branch/merge: agents branch, explore, and merge results back
 - S3-native storage, no separate object store needed
-- Unified traversal + vector + BM25 search in one Rust runtime
+- S3-native, Rust, traversal + vector + BM25 in one runtime
 - Schema-first: define node and edge types upfront
 
 ### Links

--- a/README.md
+++ b/README.md
@@ -2196,6 +2196,25 @@ Science, Multimodal, Social, Multi-agent
 
 </details>
 
+## [Omnigraph](https://github.com/ModernRelay/omnigraph)
+Typed graph database for agent memory with Git-style branch and merge
+
+<details>
+
+### Category
+Build your own, General purpose
+
+### Description
+- Typed graph database designed as persistent memory and source of truth for AI agents
+- Git-style branch/merge: agents branch, explore, and merge results back
+- S3-native storage, no separate object store needed
+- Unified traversal + vector + BM25 search in one Rust runtime
+- Schema-first: define node and edge types upfront
+
+### Links
+- [GitHub](https://github.com/ModernRelay/omnigraph)
+</details>
+
 ## [OpenAgents](https://github.com/xlang-ai/OpenAgents)
 Multi-agent general purpose platform
 <details>


### PR DESCRIPTION
Adding Omnigraph, an open-source typed graph database built in Rust for
agent memory. Agents branch and merge like Git, with traversal + vector +
BM25 search unified in one runtime.

https://github.com/ModernRelay/omnigraph