### PR TITLE
Add BenchGecko Agent Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5589,3 +5589,4 @@ We are open-source and you can get started with E2B [here](https://e2b.dev/docs?
 
 
 -->
+- [BenchGecko Agents](https://benchgecko.ai/agents) - AI agent leaderboard tracking 165 agents with SWE-bench, GAIA, OSWorld, and tau-bench scores. GitHub momentum tracking for fastest risers.


### PR DESCRIPTION
Adds BenchGecko's agent leaderboard.

Tracks 165 AI agents with capability scores across real-world evaluation benchmarks. Includes GitHub momentum tracking.

https://benchgecko.ai/agents