### PR TITLE
Add Swiss Truth MCP — verified knowledge infrastructure for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ We structured the list into two parts:
 To filter the products by categories and use-cases, see the 🌟 [web version of this list](https://e2b.dev/ai-agents). 🌟
 
 The list is done according to our best knowledge, although definitely not comprehensive. Check out also <a href="https://github.com/e2b-dev/awesome-sdks-for-ai-agents">the Awesome List of SDKs for AI Agents</a>.
+- [Swiss Truth MCP](https://github.com/swisstruthorg/swiss-truth-mcp) - Verified knowledge infrastructure for AI agents. 3000+ certified facts across 38 domains with 5-stage human+AI validation. MCP server, LangChain/CrewAI/AutoGen integrations. Prevents hallucinations on regulatory topics. ![GitHub Repo stars](https://img.shields.io/github/stars/swisstruthorg/swiss-truth-mcp?style=social)
 Discussion and feedback appreciated! :heart:
 
 ## Have anything to add?


### PR DESCRIPTION
Adding Swiss Truth MCP to the Tools & Infrastructure section.

**Swiss Truth** is verified knowledge infrastructure that gives AI agents access to 3000+ certified facts. Each fact passes a 5-stage human+AI validation pipeline with SHA256 integrity hashes.

**MCP:** `npx -y mcp-remote https://swisstruth.org/mcp`
**LangChain:** `pip install swiss-truth-langchain`
**CrewAI:** `pip install swiss-truth-crewai`
**AutoGen:** `pip install swiss-truth-autogen`
**GitHub:** https://github.com/swisstruthorg/swiss-truth-mcp

- 3000+ certified facts, 38 domains, 10 languages
- 5-stage human+AI validation pipeline
- SHA256 integrity hashes on every claim
- No API key required