### PR TITLE
Add Orallexa Marketing Agent (open-source, MCP server, 9 platforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2196,6 +2196,32 @@ Science, Multimodal, Social, Multi-agent
 
 </details>
 
+## [Orallexa Marketing Agent](https://github.com/alex-jb/orallexa-marketing-agent)
+AI marketing agent for OSS founders — drafts platform-tuned posts from your repo's commits
+
+<details>
+
+### Category
+Marketing, Content generation, Multi-platform
+
+### Description
+- 9 platform adapters: X, Reddit, LinkedIn, Bluesky, Mastodon, Threads, Dev.to, Zhihu, Xiaohongshu (last two are content-prep only — never auto-publish, per anti-bot research)
+- HITL approval queue: drafts land as markdown files; user `git mv pending → approved` to publish
+- Thompson-sampling variant bandit picks emoji-led / question-led / stat-led framings, learns engagement-winning style per platform
+- Voyager-style auto-skill promotion: top-quartile-engagement posts auto-distill into Claude Skill markdown
+- Reflexion memory: cross-session critic findings prepended to next prompt as "patterns to avoid"
+- Cloudflare Workers AI edge tier (~80% cost reduction vs Claude alone) with Anthropic Sonnet 4.6 fallback
+- Built-in MCP server (`marketing-agent-mcp`) exposes 7 tools to Claude Code / Desktop / Cursor / Zed
+- Trends loop: scans GitHub / HN / Reddit / your own VibeX top-of-feed, drafts posts connecting your project's angle to what's trending right now
+- 408 tests, 77% coverage, MIT, on PyPI
+
+### Links
+- [GitHub](https://github.com/alex-jb/orallexa-marketing-agent)
+- [PyPI](https://pypi.org/project/orallexa-marketing-agent/)
+- [CHANGELOG](https://github.com/alex-jb/orallexa-marketing-agent/blob/main/CHANGELOG.md)
+
+</details>
+
 ## [OpenAgents](https://github.com/xlang-ai/OpenAgents)
 Multi-agent general purpose platform
 <details>


### PR DESCRIPTION
## What

Adds [`alex-jb/orallexa-marketing-agent`](https://github.com/alex-jb/orallexa-marketing-agent) under the open-source projects list. Inserted alphabetically between NLSOM and OpenAgents.

## Why it fits the list

Open-source AI agent that automates social-media marketing for OSS / dev projects. Same shape as other entries (Cal.ai, BondAI, etc.) — a focused, working agent with a real differentiator, not a framework wrapper.

## Differentiators vs other content/marketing-style entries on the list

- **Variant bandit** — Thompson Beta-conjugate over `emoji-led / question-led / stat-led` framings; learns from real engagement which framing wins per channel. Most marketing tools just generate; this one closes the feedback loop.
- **Voyager-style auto-skill promotion** — top-quartile-engagement posts auto-distill into Claude Skill markdown files reusable cross-agent.
- **Reflexion memory** — cross-session critic findings prepended to next prompt as "patterns to avoid".
- **HITL approval queue** — drafts land as markdown files; never posts without human approval; UI is just `git mv` (or Streamlit, or Obsidian).
- **9 platforms** — including Bluesky firehose ($0 real-time engagement vs X's $42k/yr Enterprise webhook) and honest-prep adapters for 知乎 / 小红书 (per Q2 2026 anti-bot research, never auto-publishes there).
- **Cost-aware** — Cloudflare Workers AI edge tier as cheap drafter (~80% cost reduction) before falling back to Anthropic Sonnet 4.6.

## Quality signals

- 408 tests, 77% coverage, CI green Python 3.11 / 3.12
- MIT licensed
- Live on PyPI (Trusted Publishing OIDC)
- Bilingual README (EN + 中文)
- Built-in MCP server (`marketing-agent-mcp`) exposes 7 tools to Claude Code / Desktop / Cursor / Zed