### PR TITLE
Add Entroly context selection and recovery tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,6 +1333,28 @@ Coding
 
 </details>
 
+## [Entroly](https://github.com/juyterman1000/entroly)
+Information-theoretic context compression engine for AI coding agents
+
+<details>
+
+![Image](https://github.com/juyterman1000/entroly/raw/main/docs/assets/logo.png)
+
+### Category
+Coding, General purpose, Productivity
+
+### Description
+- A transparent local proxy and MCP server that optimizes the context window for AI coding agents (Claude Code, Cursor, Copilot).
+- Compresses codebase context by 78% on average with zero quality loss using a Rust-based information-theoretic knapsack optimizer.
+- Prevents LLM hallucinations caused by context truncation or irrelevant file inclusion.
+- Features SimHash deduplication, multi-probe LSH search, and an online RL engine (PRISM) that continuously adapts optimization weights to your codebase patterns.
+- Includes a live intelligence dashboard to monitor token consumption, dedup metrics, and actual financial savings.
+
+### Links
+- [GitHub](https://github.com/juyterman1000/entroly)
+
+</details>
+
 ## [evo.ninja](https://evo.ninja/)
 AI agent that adapts its persona to achive tasks
 

--- a/README.md
+++ b/README.md
@@ -1334,7 +1334,7 @@ Coding
 </details>
 
 ## [Entroly](https://github.com/juyterman1000/entroly)
-Information-theoretic context compression engine for AI coding agents
+Local-first context selection and recovery tools for AI agents
 
 <details>
 
@@ -1344,17 +1344,16 @@ Information-theoretic context compression engine for AI coding agents
 Coding, General purpose, Productivity
 
 ### Description
-- A transparent local proxy and MCP server that optimizes the context window for AI coding agents (Claude Code, Cursor, Copilot).
-- Compresses codebase context by 78% on average with zero quality loss using a Rust-based information-theoretic knapsack optimizer.
-- Prevents LLM hallucinations caused by context truncation or irrelevant file inclusion.
-- Features SimHash deduplication, multi-probe LSH search, and an online RL engine (PRISM) that continuously adapts optimization weights to your codebase patterns.
-- Includes a live intelligence dashboard to monitor token consumption, dedup metrics, and actual financial savings.
+- Selects evidence under an explicit token budget through an MCP server and CLI.
+- Stores omitted source spans behind content-addressed handles for exact recovery.
+- Emits auditable Context Receipts describing what was selected and omitted.
+- Includes local verification with `entroly verify-claims`; no API key is required for that check.
+- Savings and task quality are workload-dependent and should be measured before production routing.
 
 ### Links
 - [GitHub](https://github.com/juyterman1000/entroly)
 
 </details>
-
 ## [evo.ninja](https://evo.ninja/)
 AI agent that adapts its persona to achive tasks
 


### PR DESCRIPTION
Adds Entroly to the open-source projects section using this repository's heading/details format.

Entroly is an Apache-2.0, local-first MCP server and CLI for explicit-budget evidence selection, content-addressed exact recovery, and auditable Context Receipts.

Verification command: `uvx --from entroly entroly verify-claims --max-files 30`

The entry explicitly states that savings and task quality are workload-dependent. Disclosure: I maintain Entroly.

Contributor action still required: the repository CLA must be accepted by the contributor account before merge.