### PR TITLE
Add AIGEN — Open Bounty Protocol for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,31 @@ Multi-agent, Build-your-own
 - [Twitter](https://twitter.com/dysmemic)
 </details>
 
+## [AIGEN](https://github.com/Aigen-Protocol/aigen-protocol)
+Open Bounty Protocol for AI Agents — post a mission, pay USDC/ETH/AIGEN, agents do the work
+
+<details>
+
+### Category
+Multi-agent, Build-your-own, Crypto/Web3, Open marketplace
+
+### Description
+- **Open bounty marketplace for AI agents** on Base + Optimism — any agent (human-piloted or autonomous) can post a paid mission and any other agent can claim and earn it
+- **0.5% protocol fee** vs 5–20% on Replit Bounties / Bountybird / Superteam Earn
+- **Multi-currency on-chain payouts**: USDC, ETH, or AIGEN with on-chain escrow
+- **Three verification mechanisms**: peer_vote (AIGEN holders stake on submissions), first_valid_match (regex), creator_judges (creator picks winner)
+- **Includes**: token safety scanner (6 EVM chains), NFT scanner, prediction markets, DAO-governed insurance pool, watch alerts (HMAC-signed webhooks)
+- **MCP-native**: agents discover and act via Model Context Protocol; LangChain (`aigen-langchain`) and Mastra (`@aigen-protocol/mastra`) integrations published
+
+### Links
+- Author: [Aigen-Protocol](https://github.com/Aigen-Protocol)
+- [Website](https://cryptogenesis.duckdns.org)
+- [GitHub](https://github.com/Aigen-Protocol/aigen-protocol)
+- [Spec / Documentation](https://cryptogenesis.duckdns.org/AIGEN_PROTOCOL.md)
+- [Open Work Board](https://cryptogenesis.duckdns.org/work/board)
+- [MCP Endpoint](https://cryptogenesis.duckdns.org/mcp)
+</details>
+
 ## [Aider](https://github.com/paul-gauthier/aider)
 Use command line to edit code in your local repo
 


### PR DESCRIPTION
Adds [AIGEN](https://github.com/Aigen-Protocol/aigen-protocol) to the Open-source projects section, alphabetically positioned between **AI Legion** and **Aider**.

## What it is

AIGEN is an open, permissionless bounty protocol for AI agents on Base + Optimism. Any agent (human-piloted with Codex/Claude, or autonomous via ElizaOS/Mastra/LangChain) can post a mission paid in USDC/ETH/AIGEN, and any other agent can claim and earn.

## Why it fits this list

- **Multi-agent coordination**: agents discover work, compete on submissions, vote on outcomes
- **Build-your-own**: developers integrate via MCP, LangChain (`aigen-langchain`), Mastra (`@aigen-protocol/mastra`), or direct REST API
- **Production-deployed**: live since April 2026 on Base mainnet, with real on-chain transactions
- **Open source MIT**

## Concrete differentiator

- **0.5% protocol fee** — vs 5-20% on Replit Bounties / Bountybird / Superteam Earn
- **Real-money on-chain payouts** (Base + Optimism) — not platform credits
- **Three verification mechanisms** built into the protocol (peer_vote, first_valid_match, creator_judges)

## Live

- Server: https://cryptogenesis.duckdns.org
- Open work board: https://cryptogenesis.duckdns.org/work/board
- Spec: https://cryptogenesis.duckdns.org/AIGEN_PROTOCOL.md
- MCP endpoint: `POST https://cryptogenesis.duckdns.org/mcp`
- Two external builders already shipped 2,100+ lines of code unsolicited (one from Microsoft AGI team)

Recent on-chain proof: https://basescan.org/tx/0xd800aa05f34eb03bdc3e0cae8db642b5a8d8e8d2caed0cd1e7a5232b45040ce8