### PR TITLE
Add TeamOffsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5287,6 +5287,26 @@ Build-your-own, General purpose, Productivity
 </details>
 
 
+## [TeamOffsite](https://teamoffsite.ai)
+No-code platform from mercury.build to build, set up, and manage agent teams
+
+<details>
+
+### Category
+Build-your-own, Multi-agent, Productivity
+
+### Description
+- No-code platform from [mercury.build](https://mercury.build) to build, set up, and manage agent teams
+- Bring-your-own-agent support for Cursor, Claude Code, Devin, and OpenClaw
+- Orchestration and governance built in
+
+### Links
+- [Web](https://teamoffsite.ai)
+- [mercury.build](https://mercury.build)
+
+</details>
+
+
 ## [ThinkChain AI](https://www.thinkchain.ai/)
 Financial AI agent platform
 


### PR DESCRIPTION
Adds **TeamOffsite** ([teamoffsite.ai](https://teamoffsite.ai)) to the Closed-source projects and companies section.

TeamOffsite is a no-code platform to build and orchestrate teams of AI agents, with bring-your-own-agent support for Cursor, Claude Code, Devin, and OpenClaw, plus an orchestration and governance layer.

- Placed alphabetically in the closed-source section (between Taskade and ThinkChain AI)
- Follows the existing entry format (Category / Description / Links)

**Disclosure:** I'm affiliated with TeamOffsite (mercury.build) — submitting our own product. Happy to adjust wording, category, or placement to fit the list's conventions.