### PR TITLE
Add RustChain — DePIN for Vintage Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2961,6 +2961,23 @@ General purpose
 - Author: [PJ Gray](https://twitter.com/pj4533/?utm_source=awesome-ai-agents)
 </details>
 
+## [RustChain](https://github.com/Scottcjn/Rustchain)
+RustChain: DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines
+
+<details>
+
+### Category
+- DePIN / AI Agents / Blockchain
+
+### Pricing
+- Open Source
+
+### Links
+- [GitHub](https://github.com/Scottcjn/Rustchain)
+- [Website](https://rustchain.org)
+
+</details>
+
 # Closed-source projects and companies
 
 ## [Ability AI](https://ability.ai/)


### PR DESCRIPTION
## Add RustChain to Awesome AI Agents

RustChain — DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines

- **GitHub:** https://github.com/Scottcjn/Rustchain
- **Website:** https://rustchain.org
- **Description:** DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines
- **Tags:** DePIN, blockchain, AI agents, Rust, vintage hardware, Proof of Antiquity

---
Bounty #2862
Wallet: RTC502709aa4bcbc4e19001fe3808afb71aa23d19b6