### PR TITLE
Add Pulse — Claude Code sub-agent that scores X drafts vs twitter/the-algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -5589,3 +5589,5 @@ We are open-source and you can get started with E2B [here](https://e2b.dev/docs?
 
 
 -->
+
+- [Pulse](https://septimlabs.com/pulse?utm_source=awesome-list&utm_campaign=e2b-dev) - Claude Code sub-agent that scores your X (Twitter) drafts against the published [twitter/the-algorithm](https://github.com/twitter/the-algorithm) heavy-ranker weights (+75 `reply_engaged_by_author`, -74 `negative_feedback_v2`, link tax, etc.) **before** you post. Outputs a 0-100 score, 5-axis breakdown, ship/rewrite verdict, and 3-5 concrete rewrites cited to which axis lifts. Drops into `~/.claude/agents/pulse.md`. Open-source sample: [github.com/septimlabs-code/septim-agents-pack-sample](https://github.com/septimlabs-code/septim-agents-pack-sample). $49 founding rate thru Mon 2026-05-26 ($79 after). [septimlabs.com/pulse](https://septimlabs.com/pulse)


### PR DESCRIPTION
Adds **Pulse** — a Claude Code sub-agent (~6 KB markdown drop-in at `~/.claude/agents/pulse.md`) that scores X (Twitter) drafts against the **published [twitter/the-algorithm](https://github.com/twitter/the-algorithm) heavy-ranker source weights** before you post.

**What it cites:**
- `reply_engaged_by_author` (+75) — biggest positive lever
- `negative_feedback_v2` (-74) — biggest penalty
- `is_reported`, `is_random`, link tax (URLs in body bias)
- 5 scoring axes: engagement-pull, dwell, reply-bait, link-penalty, format

**Output:** 0-100 score, per-axis breakdown, ship/rewrite verdict, 3-5 concrete rewrites tied to which axis lifts.

**Open-source sample agent file (MIT):** https://github.com/septimlabs-code/septim-agents-pack-sample
**Landing + paid pack:** https://septimlabs.com/pulse — $49 founding rate thru Mon 2026-05-26 ($79 after); $999 Team unlimited seats lifetime.

Category fit: Claude Code sub-agent / Growth tooling / X-platform tools. Easy to decline if the list scopes narrower.