### PR TITLE
Add Cadence — autonomous Claude Code dev pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,29 @@ Coding
 
 </details>
 
+## [Cadence](https://github.com/axledbetter/cadence)
+Autonomous Claude Code dev pipeline (brainstorm → spec → plan → implement → migrate → validate → PR → review → bugbot)
+
+<details>
+
+### Category
+Coding
+
+### Description
+- MIT-licensed CLI that drives Claude Code through a full autonomous pipeline: brainstorm → spec → plan → implement → migrate → validate → PR → review → bugbot
+- Multi-model role split — Claude writes code, Codex reviews the diff, Cursor bugbot triages PR comments
+- Risk-tiered review depth (1/2/3 sequential Codex passes per spec risk frontmatter; auto-escalated by keyword for auth/billing/secrets/migrations/RLS/IAM)
+- Concurrent multi-PR dispatch in worktree-isolated branches
+- 16+ provider adapters (Anthropic, OpenAI, Google, Groq, Ollama, AWS Bedrock, Azure OpenAI, Cohere, Mistral, plus OpenAI-compatible: Together, Fireworks, OpenRouter, Perplexity, DeepInfra)
+- User-type profiles (solo / small-team / enterprise / oss-maintainer / learning)
+- Every phase is a rewireable Claude Code skill
+
+### Links
+- [npm](https://www.npmjs.com/package/@delegance/cadence)
+- [Repo](https://github.com/axledbetter/cadence)
+
+</details>
+
 ## [Cal.ai](https://cal.ai)
 Open-source scheduling assistant built on Cal.com
 


### PR DESCRIPTION
Adds **Cadence** (`@delegance/cadence`), an MIT-licensed CLI that runs Claude Code through an autonomous dev pipeline: brainstorm → spec → plan → implement → migrate → validate → PR → review → bugbot. The pipeline ships itself (every release is shipped by Cadence; commit history and Codex reviews preserved on the repo).

Why it fits this list: Cadence is an open-source autonomous coding agent — fits the "Coding" category alongside Aider, AutoGen, Devon, etc. Inserted alphabetically between bumpgen and Cal.ai (Open-source projects section).

Key features:
- Multi-model role split (Claude writes code, Codex reviews diff, Cursor bugbot triages PR comments)
- Risk-tiered review depth (1/2/3 sequential Codex passes per spec risk frontmatter; auto-escalated by keyword for auth/billing/secrets/migrations/RLS/IAM)
- Concurrent multi-PR dispatch in worktree-isolated branches
- 16+ provider adapters (Anthropic, OpenAI, Google, Groq, Ollama, AWS Bedrock, Azure OpenAI, Cohere, Mistral, plus OpenAI-compatible: Together, Fireworks, OpenRouter, Perplexity, DeepInfra)
- User-type profiles (solo / small-team / enterprise / oss-maintainer / learning)
- Local CLI, free, MIT

Format: matches the existing `## [Name](url)` block with category/description/links under `<details>`, alphabetical position respected.

Links:
- npm: https://www.npmjs.com/package/@delegance/cadence
- repo: https://github.com/axledbetter/cadence