### PR TITLE
Add council-diff — 5-voice AI council with Brier audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,28 @@ Coding
 
 </details>
 
+## [council-diff](https://github.com/alex-jb/council-diff)
+5-voice AI council for any decision · Brier-audited
+
+<details>
+
+### Category
+General purpose, Multi-agent, Decision support
+
+### Description
+- A small TypeScript library that uses a **single Claude Sonnet 4.6 call** to produce 5 specialist verdicts on any decision in 1 structured JSON response.
+- Counter-intuitively, asking for 5 voices in one call produces better disagreement than 5 parallel calls — the voices "see" each other in the model's context and push back. 1/5 the cost too.
+- 6 built-in domains: `founder` / `engineer` / `investor` / `career` / `product` / `quant`. Plus `custom` for fully user-defined voice rosters.
+- Includes a **persistence-agnostic Brier audit module** that scores recommendations honestly at resolution. Anyone can build a council; few will get scored.
+- ~$0.03 per deliberation. MIT, bilingual README (EN + 中文). Python port available at [council-diff-py](https://github.com/alex-jb/council-diff-py).
+
+### Links
+- [GitHub](https://github.com/alex-jb/council-diff)
+- [Live demo](https://www.vibexforge.com/council)
+- [Python port](https://github.com/alex-jb/council-diff-py)
+
+</details>
+
 ## [CrewAI](https://github.com/joaomdmoura/crewai)
 Framework for orchestrating role-playing agents
 <details>


### PR DESCRIPTION
Adds [council-diff](https://github.com/alex-jb/council-diff) to the C section (between Continue and CrewAI alphabetically).

council-diff is a small TypeScript library demonstrating a single-LLM-call multi-persona deliberation pattern. Instead of N parallel calls for N personas, one structured prompt produces N verdicts in one JSON response — the voices push back on each other inside the model's context window, which empirically produces better disagreement than parallel calls.

The bit relevant to this list:
- Single-call multi-persona pattern (different from the typical graph-orchestrator multi-agent setup)
- Includes a persistence-agnostic Brier audit module — recommendations get scored honestly at resolution, not cherry-picked
- 6 built-in voice rosters (founder/engineer/investor/career/product/quant) + custom
- ~$0.03 per deliberation with Claude Sonnet 4.6

MIT, TypeScript, bilingual README (EN + 中文). Python port also available at [council-diff-py](https://github.com/alex-jb/council-diff-py).

Live demo: https://www.vibexforge.com/council