### PR TITLE
Add atrium (closed-source projects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3319,6 +3319,29 @@ Data analysis, Business intelligence
 
 </details>
 
+## [atrium](https://getatrium.dev)
+Desktop workspace for running multiple AI coding agents side by side
+
+<details>
+
+![image](https://getatrium.dev/og/default)
+
+### Category
+Coding, Productivity
+
+### Description
+- Native macOS workspace where CLI coding agents (Claude Code, Codex, Gemini CLI, and others) run side by side with terminals, editors, and an embedded browser
+- Workspace layout, terminals, and agent sessions survive restarts and resume where they left off
+- Past agent sessions are searchable across tools
+- Free during early access
+
+### Links
+- [Web](https://getatrium.dev)
+- [X (Twitter)](https://x.com/atrium_dev)
+
+</details>
+
+
 ## [Avanzai](https://avanz.ai/)
 AI agents for portfolio risk and asset allocation
 

--- a/README.md
+++ b/README.md
@@ -3341,7 +3341,6 @@ Coding, Productivity
 
 </details>
 
-
 ## [Avanzai](https://avanz.ai/)
 AI agents for portfolio risk and asset allocation
 


### PR DESCRIPTION
Adding **[atrium](https://getatrium.dev)** to the closed-source projects list (alphabetical order, between AGENTS.inc-adjacent entries and Avanzai).

atrium is a native macOS workspace for running multiple AI coding agents (Claude Code, Codex, Gemini CLI, and others) side by side — with terminals, editors, an embedded browser, resumable sessions that survive restarts, and search across past agent sessions. Free during early access.

Entry follows the existing closed-source block format (tagline, `<details>` with image, Category, Description, Links). I'm the author.
