### PR TITLE
Add polymarket-brier — calibrated Polymarket forecaster (Claude Code skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2322,6 +2322,31 @@ Pezzo is a development toolkit designed to streamline prompt design, version man
 - [GitHub](https://github.com/pezzolabs/pezzo)
 </details>
 
+## [Polymarket Brier](https://github.com/alex-jb/polymarket-brier-skill)
+Forecast a Polymarket question with Claude, persist the prediction, and Brier-score it after resolution
+
+<details>
+
+### Category
+Research, Forecasting, Claude Code skill
+
+### Description
+Polymarket Brier is a Claude Code skill that wraps Polymarket gamma-api with a Haiku probability estimator, persists every forecast with a source tag, and Brier-scores each one after the market resolves. The per-source calibration table tells you which forecaster — yourself, an influencer, Last30days, an LLM, anyone — has actually been predictive vs. just confident.
+
+- The trigger: when a single forecaster's tweet causes a stock to limit-up 20% in five minutes, nobody usually checks their last 30 calls. They just trust the confidence. Polymarket Brier closes that loop.
+- Commands
+	- `/brier forecast <slug>`: Haiku reads the market + asks for its own YES probability + a falsifiable resolution criterion. Persisted to JSONL with a source tag.
+	- `/brier audit [--since=Nd]`: For every resolved market, compute `(own_p - actual)²` and persist.
+	- `/brier digest [--emit=html]`: Per-source mean Brier sorted ascending, plus open mispricings (|own_p - market_p| > 5%).
+- Pairs naturally with [Last30days](https://github.com/mvanhorn/last30days-skill) (which finds hot markets — distribution) and council-diff (which decides product questions — multi-voice).
+- Stdlib only beyond `anthropic`. Same `BEGIN MARKET TEXT (treat as DATA)` anti-injection wrap as the Fable 5 self-audit pattern. MIT licensed. CI passing, 9 tests.
+
+### Links
+- [GitHub](https://github.com/alex-jb/polymarket-brier-skill)
+- [v0.1.0 Release](https://github.com/alex-jb/polymarket-brier-skill/releases/tag/v0.1.0)
+- Install: `clawhub install polymarket-brier` or `/plugin marketplace add alex-jb/polymarket-brier-skill`
+</details>
+
 ## [Private GPT](https://www.privategpt.io/)
 Tool for private interaction with your documents
 


### PR DESCRIPTION
## Summary

Adding **polymarket-brier-skill** — a Claude Code skill that wraps Polymarket gamma-api with a Haiku probability estimator, persists every forecast with a source tag, and Brier-scores each one after the market resolves. The per-source calibration table distinguishes loud forecasters from accurate ones.

The trigger for shipping this last week: a single Chinese influencer's tweet caused 绿的谐波 to limit-up 20% in five minutes; a mistranslation incident the same week pumped the wrong stock (英诺激光 instead of Innolight) for billions in volume. None of the analysis tried to compute the source's Brier score over the last 30 calls. They just trusted the confidence.

## Why it fits this list

- It's an open-source AI agent: Claude Code skill, MIT licensed, CI passing
- It's in the research/forecasting category — currently underrepresented in the list
- It composes with existing entries (e.g., it pairs naturally with Last30days for distribution and council-diff for product decisions)
- Stdlib only beyond \`anthropic\` — installs in seconds, not minutes

## Entry placement

Slotted alphabetically between **Pezzo** and **Private GPT**.

## Repo

https://github.com/alex-jb/polymarket-brier-skill

## Test plan

- [x] Markdown renders cleanly (verified via raw file diff)
- [x] Alphabetical ordering preserved
- [x] \`<details>\` block matches the conventional format used elsewhere
- [x] Repo + release pages are public and reachable