### PR TITLE
Add Praxia to Open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2322,6 +2322,33 @@ Pezzo is a development toolkit designed to streamline prompt design, version man
 - [GitHub](https://github.com/pezzolabs/pezzo)
 </details>
 
+## [Praxia](https://praxia.tools/)
+Local-first multi-agent orchestrator with cyclic personal/organizational memory
+
+<details>
+
+![image](https://praxia.tools/images/brand/wordmark-square.svg)
+
+### Category
+General purpose, Multi-agent, Build your own
+
+### Description
+Praxia is an Apache 2.0 multi-agent orchestrator that turns chat into scheduled jobs, parallel file batches, and editable native PowerPoint, with personal observations auto-promoted to organizational knowledge.
+- Free-running `AutonomousAgent` (LLM-driven tool-use loop, 15+ built-in tools) and verifier-wrapped `CommandedAgent` with pre-retrieval, grounding verification, and explicit `abstain` for grounded RAG
+- 5-layer memory stack: personal → consolidation → shared org → frozen markdown (git-managed) → optional graph
+- Three independent promotion paths (frequency, outcome correlation, self-eval) — recurring patterns auto-promoted from personal to organizational memory
+- 20+ SaaS connectors with per-user OAuth (Slack, Notion, GitHub, kintone, Linear, Confluence, etc.) and MCP support (stdio + HTTP/SSE)
+- Multi-provider via LiteLLM: Claude, GPT-5, Gemini, Qwen, Ollama, LM Studio, vLLM, and 100+ others; air-gapped operation supported
+- Free Windows desktop on Microsoft Store + `pip install praxia` for CLI users
+
+### Links
+- [GitHub](https://github.com/praxia-dev/praxia)
+- [Microsoft Store](https://apps.microsoft.com/detail/9P9LSR34HZF3)
+- [PyPI](https://pypi.org/project/praxia/)
+- [Demo (4-min walkthrough)](https://youtu.be/Z3DFa2saHJg)
+
+</details>
+
 ## [Private GPT](https://www.privategpt.io/)
 Tool for private interaction with your documents
 


### PR DESCRIPTION
Adding [Praxia](https://praxia.tools/) to the **Open-source projects** section, between `Pezzo` and `Private GPT` to preserve alphabetical ordering (P-e-z → P-r-a → P-r-i).

Praxia is an Apache 2.0 multi-agent orchestrator with a cyclic personal → organizational memory promotion pipeline.

**Why it fits this list:**
- LLM-driven tool-use loop (`AutonomousAgent`) with autonomous tool selection across 15+ built-in tools
- Verifier-wrapped variant (`CommandedAgent`) with explicit `abstain` path for grounded RAG
- Three independent promotion paths (frequency / outcome / self-eval) — recurring personal patterns auto-promoted to org memory
- Active development: alpha53 published on Microsoft Store on 2026-06-23

Entry follows the existing `<details>` block format used by other open-source projects (image, Category, Description with opening paragraph + bullets, Links). Happy to adjust the category list, description bullets, or image URL based on maintainer feedback.