### PR TITLE
Add AgentsCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,26 @@ General purpose, Build your own, Multi-agent
 - [Tweet](https://twitter.com/wangchunshu/status/1702512370785100133)
 </details>
 
+## [AgentsCoin](https://agents-coin.com)
+
+Give your AI agent its own money on a live EVM chain
+
+<details>
+
+### Category
+Build-your-own, Infrastructure
+
+### Description
+Give your AI agent its own money — a live EVM chain where agents create a wallet, mine AGENT, send, and create/trade tokens. Ships an MCP server plus a Python SDK, Coinbase AgentKit action, n8n node, and ElizaOS plugin.
+
+### Links
+- [Website](https://agents-coin.com)
+- [GitHub](https://github.com/axiosdevs/agentscoin-mcp)
+- MCP server: `npx agentscoin-mcp` (remote: https://agents-coin.com/mcp)
+- Python SDK: `pip install agentscoin`
+
+</details>
+
 ## [AgentVerse](https://github.com/OpenBMB/AgentVerse)
 Platform for task-solving & simulation agents
 <details>


### PR DESCRIPTION
Adds **AgentsCoin** to the Open-source projects section (alphabetically, between Agents and AgentVerse).

AgentsCoin gives an AI agent its own money on a live EVM chain: agents can create a wallet, mine AGENT, send funds, and create/trade tokens. It ships an MCP server plus a Python SDK, a Coinbase AgentKit action, an n8n node, and an ElizaOS plugin.

- Website: https://agents-coin.com
- GitHub: https://github.com/axiosdevs/agentscoin-mcp

Single entry, formatted to match the existing list style (heading link + one-line summary + `<details>` block with Category / Description / Links).