### PR TITLE
Add Hail to Open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,7 +1653,7 @@ Build-your-own (agent-builing frameworks and platforms), General purpose, Multi-
 
 
 ## [Hail](https://github.com/hail-hq/hail)
-Phone, SMS & email for AI agents
+Give an AI agent phone, SMS & email
 
 <details>
 
@@ -1663,7 +1663,7 @@ Phone, SMS & email for AI agents
 Communication, Agent tooling, Open-source
 
 ### Description
-Phone, SMS & email for AI agents. One remote MCP server exposing call, email, and event tools, inbound and outbound; also usable via CLI, Python SDK, and OpenAPI. Self-hostable.
+Give an AI agent phone, SMS & email — one remote MCP server exposing call, email, and event tools, inbound and outbound, so an agent can actually reach people. Also usable via CLI, Python SDK, and OpenAPI. Self-hostable.
 
 ### Links
 - [GitHub](https://github.com/hail-hq/hail)

--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,29 @@ Build-your-own (agent-builing frameworks and platforms), General purpose, Multi-
 </details>
 
 
+## [Hail](https://github.com/hail-hq/hail)
+Real phone calls and email for AI agents, as tool calls
+
+<details>
+
+![Hail](https://avatars.githubusercontent.com/u/277142400?v=4)
+
+### Category
+Communication, Agent tooling, Open-source
+
+### Description
+- Hail is a self-hostable (AGPLv3) communication platform for AI agents. An agent places a phone call, sends an email, and reads back structured events as plain tool calls.
+- Available as a remote MCP server (mcp.hail.so), a CLI, a Python SDK, and an OpenAPI REST API. Point any MCP client at the endpoint, authorize once, and the tools are live.
+- Voice runs on Twilio with a realtime LLM; email on AWS SES.
+
+### Links
+- [GitHub](https://github.com/hail-hq/hail)
+- [Website](https://hail.so)
+- [MCP endpoint](https://mcp.hail.so)
+
+</details>
+
+
 ## [IX](https://github.com/kreneskyp/ix)
 Agents building, debugging, and deploying platform
 

--- a/README.md
+++ b/README.md
@@ -1653,7 +1653,7 @@ Build-your-own (agent-builing frameworks and platforms), General purpose, Multi-
 
 
 ## [Hail](https://github.com/hail-hq/hail)
-Real phone calls and email for AI agents, as tool calls
+Phone, SMS & email for AI agents, as tool calls
 
 <details>
 
@@ -1663,7 +1663,7 @@ Real phone calls and email for AI agents, as tool calls
 Communication, Agent tooling, Open-source
 
 ### Description
-- Hail is a self-hostable (AGPLv3) communication platform for AI agents. An agent places a phone call, sends an email, and reads back structured events as plain tool calls.
+- Hail is a self-hostable (AGPLv3) communication platform for AI agents — give an agent a real phone number, SMS line, and inbox. It places and receives phone calls, sends SMS, and sends/reads email as plain tool calls.
 - Available as a remote MCP server (mcp.hail.so), a CLI, a Python SDK, and an OpenAPI REST API. Point any MCP client at the endpoint, authorize once, and the tools are live.
 - Voice runs on Twilio with a realtime LLM; email on AWS SES.
 

--- a/README.md
+++ b/README.md
@@ -1653,7 +1653,7 @@ Build-your-own (agent-builing frameworks and platforms), General purpose, Multi-
 
 
 ## [Hail](https://github.com/hail-hq/hail)
-Phone, SMS & email for AI agents, as tool calls
+Phone, SMS & email for AI agents
 
 <details>
 
@@ -1663,9 +1663,7 @@ Phone, SMS & email for AI agents, as tool calls
 Communication, Agent tooling, Open-source
 
 ### Description
-- Hail is a self-hostable (AGPLv3) communication platform for AI agents — give an agent a real phone number, SMS line, and inbox. It places and receives phone calls, sends SMS, and sends/reads email as plain tool calls.
-- Available as a remote MCP server (mcp.hail.so), a CLI, a Python SDK, and an OpenAPI REST API. Point any MCP client at the endpoint, authorize once, and the tools are live.
-- Voice runs on Twilio with a realtime LLM; email on AWS SES.
+Phone, SMS & email for AI agents. One remote MCP server exposing call, email, and event tools, inbound and outbound; also usable via CLI, Python SDK, and OpenAPI. Self-hostable.
 
 ### Links
 - [GitHub](https://github.com/hail-hq/hail)


### PR DESCRIPTION
Adds [Hail](https://github.com/hail-hq/hail) under **Open-source projects**.

Hail is a self-hostable, open-source (AGPLv3) communication platform for AI agents: an agent places phone calls and sends/reads email as plain tool calls, via a remote MCP server (`mcp.hail.so`), a CLI, a Python SDK, or an OpenAPI REST API. Voice runs on Twilio with a realtime LLM; email on AWS SES.

Entry inserted alphabetically (between GPTSwarm and IX), following the existing `<details>` block format.