### PR TITLE
Add DAUDIT to closed-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3825,6 +3825,10 @@ Cykel is an AI co-pilot model that can interact with any UI, website or API in r
   
 </details>
 
+## [DAUDIT](https://www.daudit.net)
+
+Decision-context engine that audits your thinking across five dimensions before you commit to irreversible decisions. Designed for founders, investors, and operators.
+
 ## [Devin](https://www.cognition-labs.com/introducing-devin)
 The first AI software engineer
 


### PR DESCRIPTION
## What

Adding [DAUDIT](https://www.daudit.net) to the closed-source projects and companies section.

## Why

DAUDIT is a closed-source AI-powered decision-context engine that audits high-stakes decisions across five dimensions before you commit. It uses LLMs for structured analytical reasoning — a growing category of AI agent applications.

While not a traditional autonomous agent, it fits the broader category of AI-powered tools that assist with complex cognitive tasks — similar to how entries like Julius AI or Kadoa are listed.

## Format

Follows the existing alphabetical entry format: `## [Name](URL)` with description.