### PR TITLE
Add BitFun

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ General purpose, Productivity
 
 
 ## [BitFun](https://github.com/GCWing/BitFun)
-Desktop agent that works in real repos and drives your desktop
+Desktop agent that builds each task its own interface, not another chat box
 
 <details>
 
@@ -743,9 +743,10 @@ Desktop agent that works in real repos and drives your desktop
 Coding, General purpose
 
 ### Description
-- BitFun is an open-source desktop application whose Agent Runtime is written in Rust. It works inside real repositories — planning, editing files, running tests, and using Git — and also handles document work such as research, slides, spreadsheets, and reports.
-- Beyond the editor it can operate the browser, desktop applications, the terminal, and remote workspaces, so tasks that leave the codebase stay in one place.
-- Extensible through custom Agents, MCP, Skills, Mini Apps (task-specific UIs), and Codex-compatible hooks. Model-agnostic — you configure which model it runs against.
+- BitFun is an open-source desktop application whose Agent Runtime is written in Rust. Its defining idea is the Mini App: rather than pushing every task through one chat box, it builds the task its own interface — a chart, a board, a form, a panel — and binds a conversation to that interface's live state, so you ask about what is on screen instead of re-describing it.
+- Account login, cross-device session sync, and controlling one signed-in device from another run through a relay you deploy yourself, with no vendor cloud in the path — which is often what decides whether an agent is permitted inside a company network.
+- The runtime is reshapeable across four continuous tiers: custom Agents, then MCP / Skills / Codex-compatible Hooks, then Mini Apps, then source-level changes. Model-agnostic.
+- Underneath: prompt assembly is byte-stable across turns for KV cache reuse (98.67% average hit over a SWE-Bench-Pro run), and a resident cross-turn code index cuts search time up to 94.6% on Chromium-scale trees.
 
 ### Links
 - [GitHub](https://github.com/GCWing/BitFun)

--- a/README.md
+++ b/README.md
@@ -743,10 +743,10 @@ Desktop agent that builds each task its own interface, not another chat box
 Coding, General purpose
 
 ### Description
-- BitFun is an open-source desktop application whose Agent Runtime is written in Rust. Its defining idea is the Mini App: rather than pushing every task through one chat box, it builds the task its own interface — a chart, a board, a form, a panel — and binds a conversation to that interface's live state, so you ask about what is on screen instead of re-describing it.
+- BitFun is a cross-platform desktop application whose Agent Runtime is written in Rust. Its defining idea is the Mini App: rather than pushing every task through one chat box, it builds the task its own interface — a chart, a board, a form, a panel — and binds a conversation to that interface's live state, so you ask about what is on screen instead of re-describing it.
 - Account login, cross-device session sync, and controlling one signed-in device from another run through a relay you deploy yourself, with no vendor cloud in the path — which is often what decides whether an agent is permitted inside a company network.
-- The runtime is reshapeable across four continuous tiers: custom Agents, then MCP / Skills / Codex-compatible Hooks, then Mini Apps, then source-level changes. Model-agnostic.
-- Underneath: prompt assembly is byte-stable across turns for KV cache reuse (98.67% average hit over a SWE-Bench-Pro run), and a resident cross-turn code index cuts search time up to 94.6% on Chromium-scale trees.
+- The runtime is reshapeable across four continuous tiers: custom Agents, then MCP / Skills / Codex-compatible Hooks, then Mini Apps, then source-level changes. It supports multiple model providers.
+- Underneath, prompt assembly is byte-stable across turns for KV cache reuse, and a resident cross-turn code index keeps hot-file and identifier lookups available without cold rescanning.
 
 ### Links
 - [GitHub](https://github.com/GCWing/BitFun)

--- a/README.md
+++ b/README.md
@@ -732,6 +732,28 @@ General purpose, Productivity
 </details>
 
 
+## [BitFun](https://github.com/GCWing/BitFun)
+Desktop agent that works in real repos and drives your desktop
+
+<details>
+
+![Image](https://raw.githubusercontent.com/GCWing/BitFun/main/png/first_screen_screenshot.png)
+
+### Category
+Coding, General purpose
+
+### Description
+- BitFun is an open-source desktop application whose Agent Runtime is written in Rust. It works inside real repositories — planning, editing files, running tests, and using Git — and also handles document work such as research, slides, spreadsheets, and reports.
+- Beyond the editor it can operate the browser, desktop applications, the terminal, and remote workspaces, so tasks that leave the codebase stay in one place.
+- Extensible through custom Agents, MCP, Skills, Mini Apps (task-specific UIs), and Codex-compatible hooks. Model-agnostic — you configure which model it runs against.
+
+### Links
+- [GitHub](https://github.com/GCWing/BitFun)
+- [Website](https://openbitfun.com/)
+- [Releases](https://github.com/GCWing/BitFun/releases) (macOS, Windows, Linux)
+</details>
+
+
 ## [Blinky](https://github.com/seahyinghang8/blinky)
 An open-source AI debugging agent for VSCode
 

--- a/README.md
+++ b/README.md
@@ -733,25 +733,24 @@ General purpose, Productivity
 
 
 ## [BitFun](https://github.com/GCWing/BitFun)
-Desktop agent that builds each task its own interface, not another chat box
+Open-source desktop agent with task-specific Mini Apps
 
 <details>
 
-![Image](https://raw.githubusercontent.com/GCWing/BitFun/main/png/first_screen_screenshot.png)
+![Mini Apps gallery](https://raw.githubusercontent.com/GCWing/BitFun/main/png/miniapps_gallery.png)
 
 ### Category
-Coding, General purpose
+Coding, Productivity
 
 ### Description
-- BitFun is a cross-platform desktop application whose Agent Runtime is written in Rust. Its defining idea is the Mini App: rather than pushing every task through one chat box, it builds the task its own interface — a chart, a board, a form, a panel — and binds a conversation to that interface's live state, so you ask about what is on screen instead of re-describing it.
-- Account login, cross-device session sync, and controlling one signed-in device from another run through a relay you deploy yourself, with no vendor cloud in the path — which is often what decides whether an agent is permitted inside a company network.
-- The runtime is reshapeable across four continuous tiers: custom Agents, then MCP / Skills / Codex-compatible Hooks, then Mini Apps, then source-level changes. It supports multiple model providers.
-- Underneath, prompt assembly is byte-stable across turns for KV cache reuse, and a resident cross-turn code index keeps hot-file and identifier lookups available without cold rescanning.
+- An open-source desktop agent for coding and office work
+- Agentic Mini Apps give tasks dedicated interfaces such as charts, boards, forms, and panels, with conversation bound to the interface live state
+- A Rust runtime with extension paths from custom Agents and MCP / Skills / Hooks through Mini Apps and source-level customization
 
 ### Links
 - [GitHub](https://github.com/GCWing/BitFun)
 - [Website](https://openbitfun.com/)
-- [Releases](https://github.com/GCWing/BitFun/releases) (macOS, Windows, Linux)
+
 </details>
 
 


### PR DESCRIPTION
Adds [BitFun](https://github.com/GCWing/BitFun) to the project directory, placed alphabetically between BeeBot and Blinky.

BitFun is a cross-platform desktop agent with a Rust Agent Runtime and Tauri v2 host. It works in real Git repositories, supports multiple model providers, exposes MCP/Skills/Codex-compatible Hooks, and can render state-bound Mini Apps for task-specific interaction. Cross-device control can run through a self-hosted relay.

The repository core code is published under MIT. Bundled third-party content is under separate terms and is currently being reviewed, so this revision intentionally avoids a whole-distribution licensing claim. It also removes unreproducible benchmark numbers from the entry.

Category: `Coding, General purpose`. The entry follows the existing heading, details, image, category, description, and links template.

Maintainer disclosure: I maintain BitFun.