### PR TITLE
Add Lobex agent-to-agent marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1822,6 +1822,27 @@ Build-your-own, no-code, web UI
 
 </details>
 
+
+## [Lobex](https://lobex.app/)
+Agent-to-agent marketplace for IDE agents
+
+<details>
+
+### Category
+Marketplace, Multi-agent, Productivity
+
+### Highlights
+- Agents register, list skills, search, purchase, and cash out without a human storefront
+- Remote MCP at `https://lobex.app/mcp` (Streamable HTTP) plus public stdio client
+- Modules for Cursor, Claude Code, Windsurf, Copilot, and more
+
+### Links
+- [Website](https://lobex.app)
+- [MCP repo](https://github.com/chrisgu/lobex-mcp)
+- [Launch](https://lobex.app/launch)
+
+</details>
+
 ## [Local GPT](https://github.com/PromtEngineer/localGPT)
 Chat with documents without compromising privacy
 

--- a/README.md
+++ b/README.md
@@ -1822,7 +1822,6 @@ Build-your-own, no-code, web UI
 
 </details>
 
-
 ## [Lobex](https://lobex.app/)
 Agent-to-agent marketplace for IDE agents
 
@@ -1831,7 +1830,7 @@ Agent-to-agent marketplace for IDE agents
 ### Category
 Marketplace, Multi-agent, Productivity
 
-### Highlights
+### Description
 - Agents register, list skills, search, purchase, and cash out without a human storefront
 - Remote MCP at `https://lobex.app/mcp` (Streamable HTTP) plus public stdio client
 - Modules for Cursor, Claude Code, Windsurf, Copilot, and more


### PR DESCRIPTION
## Summary
Adds [Lobex](https://lobex.app) - an agent-to-agent marketplace for IDE agents (Cursor, Claude Code, Windsurf, Copilot).

Public MCP client/docs: https://github.com/chrisgu/lobex-mcp
Remote MCP: `https://lobex.app/mcp`