### PR TITLE
Add no_human

### DIFF
--- a/README.md
+++ b/README.md
@@ -2207,10 +2207,10 @@ Coding, SWE, Multi-agent
 ### Description
 - You know the loop: the agent comes back confident and wrong, and you are the one checking it ran the tests. no_human closes that loop instead.
 - Takes a task — a Jira, Linear or monday.com ticket, a GitHub or GitLab issue, or a sentence you type — and plans it, writes the change, and runs your tests.
-- **A second model that never saw the code being written reviews it**, is told to refute "done", and cites file and line for every finding. A fail blocks the pull request; a reviewer that cannot run fails closed.
+- **A second model that never saw the code being written reviews it**, is told to refute "done", and must cite the file and line for any finding it grades critical, high or medium. A fail blocks the pull request; a reviewer that cannot run fails closed.
 - **A tamper guard runs first**: a net drop in tests or assertions, a new skip, a tautological assertion or a deleted test file stops the run before a reviewer token is spent.
 - **It opens the pull request and cannot merge it.** The merge commands are denied to its sessions and pushes to protected branches are refused. Merging stays a human command.
-- Tasks run in parallel, each with a spend cap set before it starts. When it cannot finish, it stops and asks one specific question instead of inventing a diff.
+- Every task carries a spend cap set before it starts, and turning on the worker pool runs several at once. When it cannot finish, it stops and asks one specific question instead of inventing a diff.
 - Nothing to deploy: it runs on the developer's machine on SQLite and your existing git host, on your own Claude subscription (OpenAI Codex is a second backend option). Desktop apps for macOS, Windows and Linux; MIT.
 
 ### Links

--- a/README.md
+++ b/README.md
@@ -2196,6 +2196,29 @@ Science, Multimodal, Social, Multi-agent
 
 </details>
 
+## [no_human](https://github.com/no-human-ai/no_human)
+From a ticket to a reviewed pull request, on your own machine
+
+<details>
+
+### Category
+Coding, SWE, Multi-agent
+
+### Description
+- Takes a task from Jira, Linear, monday.com, or a GitHub/GitLab issue — or a sentence you type — and plans, writes, tests and delivers it as a pull request.
+- **A second model reviews the work with no memory of writing it**, is instructed to refute "done", and produces a pass/fail checklist citing file and line. A fail blocks the pull request; a reviewer that cannot run fails closed.
+- **A tamper guard runs before the review**: a net drop in tests or assertions, a new skip, a tautological assertion or a deleted test file stops the run.
+- **The agent opens the pull request and cannot merge it** — the merge verbs are denied to its sessions and pushes to protected branches are refused; merging is a human command.
+- Bounded by design: three attempts, per-attempt turn limits, and a spend cap enforced before a run starts. When it cannot finish it parks with one specific question instead of inventing a diff.
+- Runs locally on SQLite and your own Claude subscription (OpenAI Codex is a second coding-backend option). Desktop apps for macOS, Windows and Linux; MIT licensed.
+
+### Links
+- [GitHub](https://github.com/no-human-ai/no_human)
+- [Web](https://getnohuman.com)
+- [Docs](https://getnohuman.com/docs)
+
+</details>
+
 ## [OpenAgents](https://github.com/xlang-ai/OpenAgents)
 Multi-agent general purpose platform
 <details>

--- a/README.md
+++ b/README.md
@@ -2197,7 +2197,7 @@ Science, Multimodal, Social, Multi-agent
 </details>
 
 ## [no_human](https://github.com/no-human-ai/no_human)
-Hand it a ticket, get back a reviewed pull request
+From ticket to reviewed pull request. Free and open-source, on your machine
 
 <details>
 
@@ -2206,7 +2206,7 @@ Coding, SWE, Multi-agent
 
 ### Description
 - You know the loop: the agent comes back confident and wrong, and you are the one checking it ran the tests. no_human closes that loop instead.
-- Takes a task — a Jira, Linear or monday.com ticket, a GitHub or GitLab issue, or a sentence you type — and plans it, writes the change, and runs your tests.
+- Pulls tickets from Jira, Linear, monday.com, GitHub and GitLab — or takes a sentence you type — and plans the work, writes the change, and runs your tests.
 - **A second model that never saw the code being written reviews it**, is told to refute "done", and must cite the file and line for any finding it grades critical, high or medium. A fail blocks the pull request; a reviewer that cannot run fails closed.
 - **A tamper guard runs first**: a net drop in tests or assertions, a new skip, a tautological assertion or a deleted test file stops the run before a reviewer token is spent.
 - **It opens the pull request and cannot merge it.** The merge commands are denied to its sessions and pushes to protected branches are refused. Merging stays a human command.

--- a/README.md
+++ b/README.md
@@ -2197,7 +2197,7 @@ Science, Multimodal, Social, Multi-agent
 </details>
 
 ## [no_human](https://github.com/no-human-ai/no_human)
-From a ticket to a reviewed pull request, on your own machine
+Hand it a ticket, get back a reviewed pull request
 
 <details>
 
@@ -2205,12 +2205,13 @@ From a ticket to a reviewed pull request, on your own machine
 Coding, SWE, Multi-agent
 
 ### Description
-- Takes a task from Jira, Linear, monday.com, or a GitHub/GitLab issue — or a sentence you type — and plans, writes, tests and delivers it as a pull request.
-- **A second model reviews the work with no memory of writing it**, is instructed to refute "done", and produces a pass/fail checklist citing file and line. A fail blocks the pull request; a reviewer that cannot run fails closed.
-- **A tamper guard runs before the review**: a net drop in tests or assertions, a new skip, a tautological assertion or a deleted test file stops the run.
-- **The agent opens the pull request and cannot merge it** — the merge verbs are denied to its sessions and pushes to protected branches are refused; merging is a human command.
-- Bounded by design: three attempts, per-attempt turn limits, and a spend cap enforced before a run starts. When it cannot finish it parks with one specific question instead of inventing a diff.
-- Runs locally on SQLite and your own Claude subscription (OpenAI Codex is a second coding-backend option). Desktop apps for macOS, Windows and Linux; MIT licensed.
+- You know the loop: the agent comes back confident and wrong, and you are the one checking it ran the tests. no_human closes that loop instead.
+- Takes a task — a Jira, Linear or monday.com ticket, a GitHub or GitLab issue, or a sentence you type — and plans it, writes the change, and runs your tests.
+- **A second model that never saw the code being written reviews it**, is told to refute "done", and cites file and line for every finding. A fail blocks the pull request; a reviewer that cannot run fails closed.
+- **A tamper guard runs first**: a net drop in tests or assertions, a new skip, a tautological assertion or a deleted test file stops the run before a reviewer token is spent.
+- **It opens the pull request and cannot merge it.** The merge commands are denied to its sessions and pushes to protected branches are refused. Merging stays a human command.
+- Tasks run in parallel, each with a spend cap set before it starts. When it cannot finish, it stops and asks one specific question instead of inventing a diff.
+- Nothing to deploy: it runs on the developer's machine on SQLite and your existing git host, on your own Claude subscription (OpenAI Codex is a second backend option). Desktop apps for macOS, Windows and Linux; MIT.
 
 ### Links
 - [GitHub](https://github.com/no-human-ai/no_human)


### PR DESCRIPTION
Adding [no_human](https://github.com/no-human-ai/no_human) to Open source projects — **disclosure: I'm the author**.

Placed alphabetically between NLSOM and OpenAgents, in the existing entry format (title line, one-line summary, `<details>` with Category / Description / Links).

It takes a ticket (Jira, Linear, monday.com, GitHub/GitLab issue) to a reviewed pull request on the developer's own machine. What distinguishes it from the other coding agents in the list: a second model reviews the work with no memory of writing it and must cite file and line, a tamper guard blocks a net drop in tests or assertions before that review runs, and the agent opens the PR but cannot merge it. MIT, runs on your own Claude subscription (OpenAI Codex is a second backend option).