### PR TITLE
Add ENZO — self-hosted BYOK AI workspace with agents and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -2961,6 +2961,29 @@ General purpose
 - Author: [PJ Gray](https://twitter.com/pj4533/?utm_source=awesome-ai-agents)
 </details>
 
+## [ENZO](https://github.com/theguysudo/ENZO/?utm_source=awesome-ai-agents)
+Self-hosted BYOK AI workspace with agents and skills
+
+<details>
+
+![image](https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png)
+
+### Category
+General purpose, Personal assistant
+
+### Description
+- Self-hosted AI workspace: chat, agents, and skills (Gmail, Google Calendar, web search, project generation) in one Docker deployment.
+- Bring Your Own Key: runs entirely on the user's own provider API keys (Groq, OpenRouter, NVIDIA, Hugging Face, Google AI) — no middleman service and no subscription markup.
+- Keys are sealed client-side with AES-256-GCM.
+- Agents support scheduled runs and a custom agent builder that drafts an agent from a plain-language task description.
+- Open source under Apache-2.0; Docker images on ghcr.io/theguysudo/enzo.
+
+### Links
+- [GitHub](https://github.com/theguysudo/ENZO)
+- [Live demo](https://enzo-hub.duckdns.org)
+- [License: Apache-2.0](https://github.com/theguysudo/ENZO/blob/main/LICENSE)
+</details>
+
 # Closed-source projects and companies
 
 ## [Ability AI](https://ability.ai/)


### PR DESCRIPTION
Replaces #1511, which was closed because the head branch had accidentally picked up unrelated backfilled commits (and with them other authors who have not signed the CLA). This PR is a single clean commit from the current main.

Adds [ENZO](https://github.com/theguysudo/ENZO) to the open-source projects list, in alphabetical position at the end of the section.

- Self-hosted AI workspace: chat, agents, and skills (Gmail, Google Calendar, web search, project generation) in one Docker deployment.
- Bring Your Own Key: runs entirely on the user's own provider API keys (Groq, OpenRouter, NVIDIA, Hugging Face, Google AI) — no middleman service, no subscription markup. Keys are sealed client-side with AES-256-GCM.
- Agents support scheduled runs and a custom agent builder.
- Apache-2.0; Docker images on ghcr.io/theguysudo/enzo; live demo at https://enzo-hub.duckdns.org.

**Disclosure**: I am the maintainer of ENZO. I have signed the CLA as @theguysudo.

@cla-bot check